### PR TITLE
req.logout() issue with passport, changed to req.session.destroy()

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -37,7 +37,7 @@ module.exports = function(express, app, passport) {
   );
 
   app.get("/logout", function(req, res) {
-    req.logout();
+    req.session.destroy();        // stack overflow https://bit.ly/2HRDDvA
   });
 };
 


### PR DESCRIPTION
There seems to be an issue with passport's "req.logout()" not always working and a simple hack to get around the problem.

stack overflow - https://bit.ly/2HRDDvA